### PR TITLE
Support native YAML for fodder content

### DIFF
--- a/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
+++ b/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional" Version="3.1.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
+++ b/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional" Version="3.1.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.25" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
+++ b/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional" Version="3.1.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
+++ b/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional" Version="3.1.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.7.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
+++ b/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional" Version="3.1.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
+++ b/src/Eryph.GenePool.Model/Eryph.GenePool.Model.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional" Version="3.1.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
+++ b/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
+++ b/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
+++ b/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.0" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.25" />
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
+++ b/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.7.0" />
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
+++ b/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
+++ b/src/Eryph.GenePool.Packing/Eryph.GenePool.Packing.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.25" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.25" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.25" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Yaml" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/apps/src/eryph-packer/Program.cs
+++ b/src/apps/src/eryph-packer/Program.cs
@@ -296,7 +296,7 @@ packCommand.SetHandler(async context =>
                     .MapLeft(issues => Error.New("The catlet configuration is invalid.",
                         Error.Many(issues.Map(i => i.ToError()))))
                     .IfLeft(e => e.Throw());
-                var configJson = ConfigModelJsonSerializer.Serialize(catletConfig);
+                var configJson = CatletConfigJsonSerializer.Serialize(catletConfig);
                 await File.WriteAllTextAsync(Path.Combine(packFolder, "catlet.json"), configJson);
                 packableFiles.Add(new PackableFile(Path.Combine(packFolder, "catlet.json"),
                     "catlet.json", GeneType.Catlet,
@@ -404,7 +404,7 @@ packCommand.SetHandler(async context =>
                         .MapLeft(issues => Error.New($"The fodder configuration '{fodderFile.Name}' is invalid.",
                             Error.Many(issues.Map(i => i.ToError()))))
                         .IfLeft(e => e.Throw());
-                    var fodderJson = ConfigModelJsonSerializer.Serialize(fodderConfig);
+                    var fodderJson = FodderGeneConfigJsonSerializer.Serialize(fodderConfig);
                     var fodderPackFolder = Path.Combine(packFolder, "fodder");
                     if (!Directory.Exists(fodderPackFolder))
                         Directory.CreateDirectory(fodderPackFolder);


### PR DESCRIPTION
This PR adds support for specifying the fodder content directly as a YAML mapping. Additionally, the JSON serialization for catlet, fodder, and project network configurations now uses snake case.