### PR TITLE
Add qcow2 / multi-platform support to the packer

### DIFF
--- a/docs/cloud-image-compatibility.md
+++ b/docs/cloud-image-compatibility.md
@@ -1,0 +1,328 @@
+# Cloud Image Compatibility
+
+Status: **implemented** in `Eryph.GenePool.Model` — the manifest shape and its
+validation are in place (geneset manifest version **1.2**). The resolve flow
+(capability ↔ generation checks, transform/upload) remains the consumer's
+responsibility, as noted under *Open points*.
+
+## Goal
+
+eryph is gaining the ability to build catlets on public clouds, starting with
+**Azure** and **AWS** (`ec2`). A catlet's parent chain ultimately resolves to a
+base catlet whose **primary volume** is the OS disk. To run that catlet on a
+cloud, eryph needs an OS disk *for that cloud*. There are two ways to obtain one:
+
+1. **Transform path** — convert the eryph genepool VHD to the cloud's format and
+   upload it. The result is a normal volume gene, content-addressed and pinned
+   like any other, distinguished only by its `arch`
+   (`azure/amd64`, `ec2/amd64`, beside the existing `hyperv/amd64`). This already
+   fits the current model (`GenesetTagManifestData.VolumeGenes` is an array of
+   `GeneReferenceData` keyed by `arch`). Nothing new is required for it; it is the
+   fallback that always works and the path for any catlet that diverges from a
+   plain base image.
+
+2. **Substitute path** — for many base images the upload is unnecessary: an
+   equivalent **vendor / marketplace image** already exists on the cloud (every
+   cloud-init-enabled Linux image; Windows on Azure where guest services can be
+   injected via a VM extension). Instead of uploading gigabytes, eryph points the
+   build at the marketplace image and injects eryph guest services separately.
+
+This document specifies how the **substitute path** is expressed so the resolve
+flow knows *how to replace a base catlet's primary volume with a marketplace
+image*, flexibly across clouds.
+
+### Why this is not just "another volume"
+
+A marketplace image is **not byte-identical** to the eryph VHD, and vendors
+refresh their published images constantly (Azure `WindowsServer` gets new
+versions monthly; AWS SSM `.../latest` moves daily). So a marketplace mapping is
+**not** a content hash — it is a weaker *compatibility assertion*: "this vendor
+image is an acceptable stand-in for this base volume (same OS / edition /
+baseline), and eryph guest services are added on top."
+
+Two consequences drive the design:
+
+- **The mapping is mutable and rolls forward.** It must therefore live in the
+  **mutable, family-level `geneset.json` (`GenesetManifestData`)** — *not* in the
+  hash-pinned tag manifest (`GenesetTagManifestData`). The marketplace equivalent
+  of "Windows Server 2022 Standard" is a property of the *family*, not of each
+  dated build, and putting it in the immutable tag would force a new tag on every
+  vendor refresh. Putting it in `geneset.json` lets it change freely without
+  invalidating any pinned tag.
+- **No identity is duplicated into the geneset/tag.** What an image *is*
+  (`secure_boot`, `tpm` ⇒ generation, OS/edition) is **catlet-model** information
+  that already lives in the catlet. The compatibility mapping is purely a
+  distribution-layer concern: `drive → candidate cloud images`. The capability ↔
+  generation check (don't resolve a TPM/secure-boot catlet onto a Gen1 SKU) is
+  performed by the **resolve engine** comparing the catlet's declared
+  capabilities against the chosen image — not by storing a copy of the identity.
+
+### Scope of this iteration
+
+- **Base catlets only.** Mixed / customized catlets that diverge from a plain
+  base image use the transform/upload path and never need a substitute.
+- **Azure + AWS (`ec2`)** reference types. GCP etc. can be added later without
+  changing the shape.
+- **Roll-forward by default** (Azure `version: latest`, AWS SSM `.../latest`).
+  Explicit pinning can be added later as an opt-in.
+
+## Schema
+
+A new optional `cloud_compatibility` member is added to `geneset.json`
+(`GenesetManifestData`). It maps each **drive name** to a **flat, ordered array**
+of candidate image references:
+
+```jsonc
+{
+  "geneset": "dbosoft/winsrv2022-standard",
+  "public": true,
+  "short_description": "Windows Server 2022 Standard",
+
+  "cloud_compatibility": {
+    "sda": [
+      {
+        "cloud": "azure",
+        "type": "azure_marketplace",
+        "publisher": "MicrosoftWindowsServer",
+        "offer": "WindowsServer",
+        "sku": "2022-datacenter-g2",
+        "version": "latest",
+        "guest_services_injection": "extension"
+      },
+      {
+        "cloud": "ec2",
+        "type": "ec2_ssm_parameter",
+        "parameter": "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+        "guest_services_injection": "geneset"
+      },
+      {
+        "cloud": "ec2",
+        "type": "ec2_image_filter",
+        "owner": "amazon",
+        "name_pattern": "Windows_Server-2022-English-Full-Base-*",
+        "guest_services_injection": "geneset"
+      }
+    ]
+  }
+}
+```
+
+### Structure rules
+
+- `cloud_compatibility` is a map of **drive name** (matching a drive in the catlet,
+  e.g. `sda`) to an **ordered array** of entries.
+- Each entry is **fully self-contained** and identified by two discriminators:
+  - `cloud` — one of the known clouds (`azure`, `ec2`), aligned with
+    `Hypervisors.KnownNames`. (`ec2` is AWS.)
+  - `type` — the reference shape (see below). `cloud` + `type` together select the
+    body fields.
+- **Order is preference.** Multiple candidates for the same cloud are simply
+  consecutive entries; the resolver takes the first that resolves.
+- Adding a new cloud or reference type never changes the shape — it is just a new
+  `cloud`/`type` value.
+
+### `guest_services_injection`
+
+A vanilla marketplace image does not ship eryph guest services (cloudbase-init
+has been removed). This field is a **strategy** telling the build *how* to inject
+them; eryph's internal logic owns the concrete mechanics (which extension, which
+geneset version):
+
+| Value       | Meaning |
+|-------------|---------|
+| `extension` | Inject via the cloud's VM-extension model (e.g. a published eryph guest-services Azure VM extension). |
+| `geneset`   | Add the eryph guest-services geneset as fodder and let **cloud-init** install it (natural Linux / AWS path). |
+| `none`      | The image already ships eryph guest services; nothing to inject. |
+
+The value is a strategy, **not** a concrete extension name or geneset reference,
+so it can evolve without editing every base catlet. The enum is open for future
+values.
+
+### Reference types
+
+#### `azure_marketplace` (cloud: `azure`)
+
+| Field     | Required | Notes |
+|-----------|----------|-------|
+| `publisher` | yes | Marketplace publisher. |
+| `offer`     | yes | Marketplace offer. |
+| `sku`       | yes | SKU. Generation/security is encoded here (e.g. `-g2` ⇒ Gen2 / Trusted Launch). |
+| `version`   | no  | `latest` (default, rolls forward) or a pinned version. |
+| `plan`      | no  | `{ publisher, product, name }` for paid / BYOL images. |
+
+#### `ec2_ssm_parameter` (cloud: `ec2`)
+
+| Field       | Required | Notes |
+|-------------|----------|-------|
+| `parameter` | yes | Public SSM parameter path resolving to an AMI id (e.g. `/aws/service/ami-windows-latest/...`). Region-independent, rolls forward. |
+
+#### `ec2_image_filter` (cloud: `ec2`)
+
+For images with no published SSM parameter. Selects the most recent matching AMI.
+
+| Field          | Required | Notes |
+|----------------|----------|-------|
+| `owner`        | yes | AMI owner alias or account id (e.g. `amazon`, Canonical `099720109477`). |
+| `name_pattern` | yes | AMI name glob; newest match wins. |
+| `architecture` | no  | e.g. `x86_64`, `arm64`. |
+
+## Resolve flow
+
+For a target cloud `C` and the catlet's primary drive:
+
+1. Does the pinned tag (`GenesetTagManifestData.VolumeGenes`) contain a volume
+   with `arch` = `C/<cpu>` (e.g. `azure/amd64`)? → **transform path**: use it.
+   This always wins when present.
+2. Otherwise read `geneset.json` `cloud_compatibility[drive]` and take the entries with
+   `cloud == C`, in order.
+3. For each candidate, validate it against the **catlet's** declared capabilities
+   (e.g. `secure_boot` + `tpm` require an Azure Gen2/Trusted-Launch SKU /
+   AWS UEFI + NitroTPM image). Reject mismatches rather than discovering them at
+   boot.
+4. Resolve the first valid candidate to a concrete image (roll forward) and
+   apply its `guest_services_injection` strategy.
+5. If neither a transformed volume nor a usable mapping exists for `C`, either
+   fall back to transform-and-upload on demand or fail with a clear message.
+
+## Suggested model changes (`Eryph.GenePool.Model`)
+
+Add to `GenesetManifestData`:
+
+```csharp
+[JsonPropertyName("cloud_compatibility")]
+public Dictionary<string, CloudImageReference[]>? CloudCompatibility { get; set; }
+```
+
+New types (sketch — `cloud` + `type` are the discriminators; a polymorphic
+`JsonConverter` keyed on `type` is the natural way to bind the bodies):
+
+```csharp
+public class CloudImageReference
+{
+    [JsonPropertyName("cloud")]                    // azure | ec2  (Hypervisors.KnownNames)
+    public string? Cloud { get; set; }
+
+    [JsonPropertyName("type")]                     // azure_marketplace | ec2_ssm_parameter | ec2_image_filter
+    public string? Type { get; set; }
+
+    [JsonPropertyName("guest_services_injection")] // extension | geneset | none
+    public string? GuestServicesInjection { get; set; }
+
+    // azure_marketplace
+    [JsonPropertyName("publisher")] public string? Publisher { get; set; }
+    [JsonPropertyName("offer")]     public string? Offer { get; set; }
+    [JsonPropertyName("sku")]       public string? Sku { get; set; }
+    [JsonPropertyName("version")]   public string? Version { get; set; }
+    [JsonPropertyName("plan")]      public AzurePlan? Plan { get; set; }
+
+    // ec2_ssm_parameter
+    [JsonPropertyName("parameter")] public string? Parameter { get; set; }
+
+    // ec2_image_filter
+    [JsonPropertyName("owner")]        public string? Owner { get; set; }
+    [JsonPropertyName("name_pattern")] public string? NamePattern { get; set; }
+    [JsonPropertyName("architecture")] public string? Architecture { get; set; }
+}
+```
+
+Consider new constant holders to mirror existing ones (`Hypervisors`,
+`Architectures`): `CloudImageReferenceTypes` (`azure_marketplace`, …) and
+`GuestServicesInjectionMethods` (`extension`, `geneset`, `none`), plus validation in
+`ManifestValidations`.
+
+## Formal JSON Schema (draft 2020-12)
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eryph.io/schemas/geneset-compatibility.json",
+  "title": "Geneset cloud image compatibility",
+  "type": "object",
+  "properties": {
+    "cloud_compatibility": {
+      "type": "object",
+      "description": "Map of drive name to ordered list of cloud image candidates.",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/cloudImageReference" }
+      }
+    }
+  },
+  "$defs": {
+    "guestServicesInjection": {
+      "type": "string",
+      "enum": ["extension", "geneset", "none"]
+    },
+    "cloudImageReference": {
+      "type": "object",
+      "required": ["cloud", "type"],
+      "properties": {
+        "cloud": { "type": "string", "enum": ["azure", "ec2"] },
+        "type": { "type": "string" },
+        "guest_services_injection": { "$ref": "#/$defs/guestServicesInjection" }
+      },
+      "oneOf": [
+        {
+          "title": "azure_marketplace",
+          "properties": {
+            "cloud": { "const": "azure" },
+            "type": { "const": "azure_marketplace" },
+            "publisher": { "type": "string" },
+            "offer": { "type": "string" },
+            "sku": { "type": "string" },
+            "version": { "type": "string", "default": "latest" },
+            "plan": {
+              "type": "object",
+              "properties": {
+                "publisher": { "type": "string" },
+                "product": { "type": "string" },
+                "name": { "type": "string" }
+              },
+              "required": ["publisher", "product", "name"]
+            },
+            "guest_services_injection": { "$ref": "#/$defs/guestServicesInjection" }
+          },
+          "required": ["publisher", "offer", "sku"],
+          "additionalProperties": false
+        },
+        {
+          "title": "ec2_ssm_parameter",
+          "properties": {
+            "cloud": { "const": "ec2" },
+            "type": { "const": "ec2_ssm_parameter" },
+            "parameter": { "type": "string" },
+            "guest_services_injection": { "$ref": "#/$defs/guestServicesInjection" }
+          },
+          "required": ["parameter"],
+          "additionalProperties": false
+        },
+        {
+          "title": "ec2_image_filter",
+          "properties": {
+            "cloud": { "const": "ec2" },
+            "type": { "const": "ec2_image_filter" },
+            "owner": { "type": "string" },
+            "name_pattern": { "type": "string" },
+            "architecture": { "type": "string" },
+            "guest_services_injection": { "$ref": "#/$defs/guestServicesInjection" }
+          },
+          "required": ["owner", "name_pattern"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}
+```
+
+## Open points for implementation
+
+- **Capability ↔ generation validation** lives in the resolve engine (eryph-zero),
+  not in the genepool client; the client only models and validates the manifest
+  shape.
+- **Cloud naming**: this doc uses `ec2` for AWS to match `Hypervisors`/
+  `Architectures`. Confirm `type` prefixes (`ec2_*`) follow the same convention.
+- **Explicit version pinning** (opt-in, for reproducibility) is intentionally
+  out of scope here; the field set leaves room (`version` on Azure; a pinned AMI
+  id type for EC2) when needed.
+```

--- a/src/Eryph.GenePool.Model/Architectures.cs
+++ b/src/Eryph.GenePool.Model/Architectures.cs
@@ -1,16 +1,32 @@
-﻿namespace Eryph.GenePool.Model;
+﻿using System.Collections.Generic;
+
+namespace Eryph.GenePool.Model;
 
 public static class Architectures
 {
     public const string HyperVAmd64 = $"{Hypervisors.HyperV}/{ProcessorTypes.Amd64}";
     public const string HyperVAny = $"{Hypervisors.HyperV}/any";
+    public const string KvmAmd64 = $"{Hypervisors.Kvm}/{ProcessorTypes.Amd64}";
+    public const string KvmAny = $"{Hypervisors.Kvm}/any";
+    public const string AzureAmd64 = $"{Hypervisors.Azure}/{ProcessorTypes.Amd64}";
+    public const string AzureAny = $"{Hypervisors.Azure}/any";
+    public const string EC2Amd64 = $"{Hypervisors.EC2}/{ProcessorTypes.Amd64}";
+    public const string EC2Any = $"{Hypervisors.EC2}/any";
     public const string Any = "any";
 
-
+    public static readonly IReadOnlyCollection<string> KnownNames = new[]
+    {
+        HyperVAmd64, HyperVAny,
+        KvmAmd64, KvmAny,
+        AzureAmd64, AzureAny,
+        EC2Amd64, EC2Any,
+        Any,
+    };
 }
 
 public static class ProcessorTypes
 {
     public const string Amd64 = "amd64";
-    
+
+    public static readonly IReadOnlyCollection<string> KnownNames = new[] { Amd64 };
 }

--- a/src/Eryph.GenePool.Model/AzurePlan.cs
+++ b/src/Eryph.GenePool.Model/AzurePlan.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Eryph.GenePool.Model;
+
+/// <summary>
+/// Purchase plan for a paid / BYOL Azure marketplace image.
+/// </summary>
+public class AzurePlan
+{
+    [JsonPropertyName("publisher")]
+    public string? Publisher { get; set; }
+
+    [JsonPropertyName("product")]
+    public string? Product { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/src/Eryph.GenePool.Model/CloudImageReference.cs
+++ b/src/Eryph.GenePool.Model/CloudImageReference.cs
@@ -1,0 +1,65 @@
+using System.Text.Json.Serialization;
+
+namespace Eryph.GenePool.Model;
+
+/// <summary>
+/// A single candidate cloud image that may be substituted for a base catlet's
+/// primary volume when building on a public cloud. Each reference is fully
+/// self-contained and identified by the <see cref="Cloud"/> + <see cref="Type"/>
+/// discriminators which together select the meaningful body fields.
+/// </summary>
+public class CloudImageReference
+{
+    /// <summary>
+    /// The target cloud, one of <see cref="Hypervisors.Azure"/> or
+    /// <see cref="Hypervisors.EC2"/>.
+    /// </summary>
+    [JsonPropertyName("cloud")]
+    public string? Cloud { get; set; }
+
+    /// <summary>
+    /// The reference shape, one of <see cref="CloudImageReferenceTypes"/>.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Strategy for injecting eryph guest services into the substituted image,
+    /// one of <see cref="GuestServicesInjectionMethods"/>.
+    /// </summary>
+    [JsonPropertyName("guest_services_injection")]
+    public string? GuestServicesInjection { get; set; }
+
+    // azure-marketplace
+
+    [JsonPropertyName("publisher")]
+    public string? Publisher { get; set; }
+
+    [JsonPropertyName("offer")]
+    public string? Offer { get; set; }
+
+    [JsonPropertyName("sku")]
+    public string? Sku { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("plan")]
+    public AzurePlan? Plan { get; set; }
+
+    // ec2-ssm-parameter
+
+    [JsonPropertyName("parameter")]
+    public string? Parameter { get; set; }
+
+    // ec2-image-filter
+
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name_pattern")]
+    public string? NamePattern { get; set; }
+
+    [JsonPropertyName("architecture")]
+    public string? Architecture { get; set; }
+}

--- a/src/Eryph.GenePool.Model/CloudImageReferenceTypes.cs
+++ b/src/Eryph.GenePool.Model/CloudImageReferenceTypes.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Eryph.GenePool.Model;
+
+public static class CloudImageReferenceTypes
+{
+    public const string AzureMarketplace = "azure_marketplace";
+    public const string Ec2SsmParameter = "ec2_ssm_parameter";
+    public const string Ec2ImageFilter = "ec2_image_filter";
+
+    public static readonly IReadOnlyCollection<string> KnownNames =
+        new[] { AzureMarketplace, Ec2SsmParameter, Ec2ImageFilter };
+}

--- a/src/Eryph.GenePool.Model/GeneModelDefaults.cs
+++ b/src/Eryph.GenePool.Model/GeneModelDefaults.cs
@@ -26,7 +26,7 @@ namespace Eryph.GenePool.Model
         }
 
         public static Version LatestGeneManifestVersion = new (1, 1);
-        public static Version LatestGenesetManifestVersion = new(1, 1);
+        public static Version LatestGenesetManifestVersion = new(1, 2);
         public static Version LatestGenesetTagManifestVersion = new(1, 1);
 
         public const int MaxYamlSourceBytes = 2 * 1024 * 1024;

--- a/src/Eryph.GenePool.Model/GenesetManifestData.cs
+++ b/src/Eryph.GenePool.Model/GenesetManifestData.cs
@@ -29,4 +29,12 @@ public class GenesetManifestData
 
     [JsonPropertyName("metadata")]
     public Dictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Maps a catlet drive name (e.g. <c>sda</c>) to an ordered list of
+    /// candidate cloud images that may be substituted for that drive when
+    /// building on a public cloud. Order expresses preference.
+    /// </summary>
+    [JsonPropertyName("cloud_compatibility")]
+    public Dictionary<string, CloudImageReference[]>? CloudCompatibility { get; set; }
 }

--- a/src/Eryph.GenePool.Model/GuestServicesInjectionMethods.cs
+++ b/src/Eryph.GenePool.Model/GuestServicesInjectionMethods.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Eryph.GenePool.Model;
+
+/// <summary>
+/// Strategies for adding eryph guest services to a substituted cloud image.
+/// The set is intentionally open for future values.
+/// </summary>
+public static class GuestServicesInjectionMethods
+{
+    public const string Extension = "extension";
+    public const string Geneset = "geneset";
+    public const string None = "none";
+
+    public static readonly IReadOnlyCollection<string> KnownNames =
+        new[] { Extension, Geneset, None };
+}

--- a/src/Eryph.GenePool.Model/Hypervisors.cs
+++ b/src/Eryph.GenePool.Model/Hypervisors.cs
@@ -1,8 +1,14 @@
-﻿namespace Eryph.GenePool.Model;
+﻿using System.Collections.Generic;
+
+namespace Eryph.GenePool.Model;
 
 public static class Hypervisors
 {
     public const string HyperV = "hyperv";
+    public const string Kvm = "kvm";
+    public const string Azure = "azure";
+    public const string EC2 = "ec2";
 
-
+    public static readonly IReadOnlyCollection<string> KnownNames =
+        new[] { HyperV, Kvm, Azure, EC2 };
 }

--- a/src/Eryph.GenePool.Model/ManifestValidations.cs
+++ b/src/Eryph.GenePool.Model/ManifestValidations.cs
@@ -1,4 +1,5 @@
-﻿using Dbosoft.Functional.Validations;
+﻿using System.Linq;
+using Dbosoft.Functional.Validations;
 using Eryph.ConfigModel;
 using LanguageExt;
 using LanguageExt.Common;
@@ -99,12 +100,10 @@ public class ManifestValidations
     {
         return
             from gNull in guard(notEmpty(architecture), Validations.BadRequestError("Architecture is empty")).ToValidation()
-            from gVal in guard(string.Equals(architecture,Architectures.HyperVAmd64) 
-                               || string.Equals(architecture, Architectures.HyperVAny) 
-                               || string.Equals(architecture, Architectures.Any),
-                Validations.BadRequestError($"Architecture value has to be '{Architectures.HyperVAmd64}'" +
-                                            $", '{Architectures.HyperVAny}' " +
-                                            $"or '{Architectures.Any}'")).ToValidation()
+            from gVal in guard(Architectures.KnownNames.Contains(architecture),
+                Validations.BadRequestError(
+                    $"Architecture value has to be one of {string.Join(", ", Architectures.KnownNames.Select(n => $"'{n}'"))}."))
+                .ToValidation()
 
             select Unit.Default;
     }

--- a/src/Eryph.GenePool.Model/ManifestValidations.cs
+++ b/src/Eryph.GenePool.Model/ManifestValidations.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Dbosoft.Functional.Validations;
 using Eryph.ConfigModel;
 using LanguageExt;
@@ -31,7 +33,8 @@ public class ManifestValidations
                | ValidateProperty(manifest, m => m.ShortDescription, Validations.ValidateGenesetShortDescription, path, true)
                | ValidateProperty(manifest, m => m.Description, Validations.ValidateGenesetDescription, path)
                | ValidateProperty(manifest, m => m.DescriptionMarkdown, Validations.ValidateMarkdownContentSize, path)
-               | ValidateProperty(manifest, m => m.Metadata, Validations.ValidateGenesetMetadata, path);
+               | ValidateProperty(manifest, m => m.Metadata, Validations.ValidateGenesetMetadata, path)
+               | ValidateCloudCompatibility(manifest.CloudCompatibility, AppendPath(path, "cloud_compatibility"));
     }
 
     public static Validation<ValidationIssue, Unit> ValidateGeneManifest(GeneManifestData manifest, string path = "")
@@ -107,4 +110,130 @@ public class ManifestValidations
 
             select Unit.Default;
     }
+
+    public static Validation<ValidationIssue, Unit> ValidateCloudCompatibility(
+        Dictionary<string, CloudImageReference[]>? cloudCompatibility, string path)
+    {
+        if (cloudCompatibility is null)
+            return Success<ValidationIssue, Unit>(Unit.Default);
+
+        return cloudCompatibility.Aggregate(
+            Success<ValidationIssue, Unit>(Unit.Default),
+            (acc, kv) =>
+            {
+                var drivePath = AppendPath(path, kv.Key);
+                var keyValidation = ValidateCloudCompatibilityDriveName(kv.Key)
+                    .MapFail(e => new ValidationIssue(drivePath, e.Message));
+                var entriesValidation = (kv.Value ?? [])
+                    .Select((entry, i) => ValidateCloudImageReference(entry, $"{drivePath}[{i}]"))
+                    .Aggregate(Success<ValidationIssue, Unit>(Unit.Default), (a, b) => a | b);
+                return acc | keyValidation | entriesValidation;
+            });
+    }
+
+    public static Validation<ValidationIssue, Unit> ValidateCloudImageReference(
+        CloudImageReference reference, string path)
+    {
+        return ValidateProperty(reference, x => x.Cloud, ValidateCloud, path, required: true)
+               | ValidateProperty(reference, x => x.Type, ValidateCloudImageReferenceType, path, required: true)
+               | ValidateProperty(reference, x => x.GuestServicesInjection, ValidateGuestServicesInjection, path)
+               | ValidateCloudImageReferenceBody(reference, path);
+    }
+
+    private static Validation<ValidationIssue, Unit> ValidateCloudImageReferenceBody(
+        CloudImageReference reference, string path)
+    {
+        Validation<ValidationIssue, Unit> Require(string? value, string field) =>
+            guard(!string.IsNullOrWhiteSpace(value),
+                    new ValidationIssue(path,
+                        $"'{field}' is required for cloud image reference type '{reference.Type}'."))
+                .ToValidation();
+
+        Validation<ValidationIssue, Unit> RequireCloud(string expected) =>
+            guard(string.Equals(reference.Cloud, expected, StringComparison.Ordinal),
+                    new ValidationIssue(path,
+                        $"Cloud image reference type '{reference.Type}' requires cloud '{expected}'."))
+                .ToValidation();
+
+        return reference.Type switch
+        {
+            CloudImageReferenceTypes.AzureMarketplace =>
+                RequireCloud(Hypervisors.Azure)
+                | Require(reference.Publisher, "publisher")
+                | Require(reference.Offer, "offer")
+                | Require(reference.Sku, "sku")
+                | ValidateAzurePlan(reference.Plan, path),
+            CloudImageReferenceTypes.Ec2SsmParameter =>
+                RequireCloud(Hypervisors.EC2)
+                | Require(reference.Parameter, "parameter"),
+            CloudImageReferenceTypes.Ec2ImageFilter =>
+                RequireCloud(Hypervisors.EC2)
+                | Require(reference.Owner, "owner")
+                | Require(reference.NamePattern, "name_pattern"),
+            _ => Success<ValidationIssue, Unit>(Unit.Default),
+        };
+    }
+
+    private static Validation<ValidationIssue, Unit> ValidateAzurePlan(AzurePlan? plan, string path)
+    {
+        if (plan is null)
+            return Success<ValidationIssue, Unit>(Unit.Default);
+
+        Validation<ValidationIssue, Unit> Require(string? value, string field) =>
+            guard(!string.IsNullOrWhiteSpace(value),
+                    new ValidationIssue(path, $"'plan.{field}' is required for an Azure marketplace plan."))
+                .ToValidation();
+
+        return Require(plan.Publisher, "publisher")
+               | Require(plan.Product, "product")
+               | Require(plan.Name, "name");
+    }
+
+    public static Validation<Error, Unit> ValidateCloudCompatibilityDriveName(string driveName)
+    {
+        return
+            from gNull in guard(notEmpty(driveName),
+                Validations.BadRequestError("Cloud compatibility drive name is empty")).ToValidation()
+            from gLen in guard(driveName.Length <= 50,
+                Validations.BadRequestError("Cloud compatibility drive name is too long (max. 50 chars).")).ToValidation()
+            select Unit.Default;
+    }
+
+    public static Validation<Error, Unit> ValidateCloud(string cloud)
+    {
+        return
+            from gNull in guard(notEmpty(cloud), Validations.BadRequestError("Cloud is empty")).ToValidation()
+            from gVal in guard(cloud is Hypervisors.Azure or Hypervisors.EC2,
+                    Validations.BadRequestError(
+                        $"Cloud value has to be one of '{Hypervisors.Azure}', '{Hypervisors.EC2}'."))
+                .ToValidation()
+            select Unit.Default;
+    }
+
+    public static Validation<Error, Unit> ValidateCloudImageReferenceType(string type)
+    {
+        return
+            from gNull in guard(notEmpty(type),
+                Validations.BadRequestError("Cloud image reference type is empty")).ToValidation()
+            from gVal in guard(CloudImageReferenceTypes.KnownNames.Contains(type),
+                    Validations.BadRequestError(
+                        $"Cloud image reference type has to be one of {string.Join(", ", CloudImageReferenceTypes.KnownNames.Select(n => $"'{n}'"))}."))
+                .ToValidation()
+            select Unit.Default;
+    }
+
+    public static Validation<Error, Unit> ValidateGuestServicesInjection(string method)
+    {
+        return
+            from gNull in guard(notEmpty(method),
+                Validations.BadRequestError("Guest services injection method is empty")).ToValidation()
+            from gVal in guard(GuestServicesInjectionMethods.KnownNames.Contains(method),
+                    Validations.BadRequestError(
+                        $"Guest services injection method has to be one of {string.Join(", ", GuestServicesInjectionMethods.KnownNames.Select(n => $"'{n}'"))}."))
+                .ToValidation()
+            select Unit.Default;
+    }
+
+    private static string AppendPath(string path, string segment) =>
+        string.IsNullOrEmpty(path) ? segment : $"{path}.{segment}";
 }

--- a/src/Eryph.GenePool.Model/ManifestValidations.cs
+++ b/src/Eryph.GenePool.Model/ManifestValidations.cs
@@ -124,9 +124,19 @@ public class ManifestValidations
                 var drivePath = AppendPath(path, kv.Key);
                 var keyValidation = ValidateCloudCompatibilityDriveName(kv.Key)
                     .MapFail(e => new ValidationIssue(drivePath, e.Message));
-                var entriesValidation = (kv.Value ?? [])
-                    .Select((entry, i) => ValidateCloudImageReference(entry, $"{drivePath}[{i}]"))
-                    .Aggregate(Success<ValidationIssue, Unit>(Unit.Default), (a, b) => a | b);
+                var entriesValidation = kv.Value is null
+                    ? Fail<ValidationIssue, Unit>(new ValidationIssue(drivePath,
+                        "Cloud compatibility entries must be an array."))
+                    : kv.Value
+                        .Select((entry, i) =>
+                        {
+                            var entryPath = $"{drivePath}[{i}]";
+                            return entry is null
+                                ? Fail<ValidationIssue, Unit>(new ValidationIssue(entryPath,
+                                    "Cloud image reference must not be null."))
+                                : ValidateCloudImageReference(entry, entryPath);
+                        })
+                        .Aggregate(Success<ValidationIssue, Unit>(Unit.Default), (a, b) => a | b);
                 return acc | keyValidation | entriesValidation;
             });
     }

--- a/src/Eryph.GenePool.Packing/GeneCompression.cs
+++ b/src/Eryph.GenePool.Packing/GeneCompression.cs
@@ -1,0 +1,8 @@
+namespace Eryph.GenePool.Packing;
+
+public enum GeneCompression
+{
+    Default,
+    Extreme,
+    None,
+}

--- a/src/Eryph.GenePool.Packing/GenePacker.cs
+++ b/src/Eryph.GenePool.Packing/GenePacker.cs
@@ -28,11 +28,12 @@ public static class GenePacker
         var targetStream = new GenePackerStream(new DirectoryInfo(tempDir), ChunkSize);
         try
         {
-            var format = file.ExtremeCompression switch
+            var format = file.Compression switch
             {
-                true => "xz",
-                false when originalSize >= GeneModelDefaults.MinCompressionBytes => "gz",
-                false => "plain"
+                GeneCompression.Extreme => "xz",
+                GeneCompression.None => "plain",
+                _ when originalSize >= GeneModelDefaults.MinCompressionBytes => "gz",
+                _ => "plain"
             };
 
             await CompressAsync(targetStream, file.FullPath, format, progress, token);

--- a/src/Eryph.GenePool.Packing/PackableFile.cs
+++ b/src/Eryph.GenePool.Packing/PackableFile.cs
@@ -1,5 +1,5 @@
-﻿using Eryph.GenePool.Model;
+using Eryph.GenePool.Model;
 
 namespace Eryph.GenePool.Packing;
 
-public record PackableFile(string FullPath, string FileName, GeneType GeneType, string Architecture, string GeneName, bool ExtremeCompression, string? YamlContent);
+public record PackableFile(string FullPath, string FileName, GeneType GeneType, string Architecture, string GeneName, GeneCompression Compression, string? YamlContent);

--- a/src/Eryph.GenePool.Packing/VMExport.cs
+++ b/src/Eryph.GenePool.Packing/VMExport.cs
@@ -1,51 +1,128 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Nodes;
 using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.Yaml;
 using Eryph.GenePool.Model;
 
 namespace Eryph.GenePool.Packing;
 
 public static class VMExport
 {
+    private static readonly Dictionary<string, (string DefaultArchitecture, GeneCompression Compression)>
+        VolumeExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [".vhdx"] = (Architectures.HyperVAmd64, GeneCompression.Extreme),
+            [".vhd"]  = (Architectures.HyperVAmd64, GeneCompression.Extreme),
+            [".qcow2"] = (Architectures.KvmAmd64, GeneCompression.None),
+        };
+
     public static (CatletConfig? Config, IEnumerable<PackableFile> Files) ExportToPackable(DirectoryInfo vmExport,
         CancellationToken token)
     {
         var files = new List<PackableFile>();
-        var vmPlan = ConvertVmDataToConfig(vmExport) ?? new CatletConfig();
+        var catletFromYaml = ReadCatletConfig(vmExport);
+        var vmPlan = catletFromYaml
+                     ?? ConvertVmDataToConfig(vmExport)
+                     ?? new CatletConfig();
 
-        var vhdFiles = vmExport.GetFiles("*.vhdx", SearchOption.AllDirectories);
-
-        foreach (var vhdFile in vhdFiles)
+        foreach (var volumeFile in vmExport.GetFiles("*", SearchOption.AllDirectories))
         {
             token.ThrowIfCancellationRequested();
 
-            files.Add(new PackableFile(vhdFile.FullName, vhdFile.Name,
-                GeneType.Volume, 
-                Architectures.HyperVAmd64,
-                Path.GetFileNameWithoutExtension(vhdFile.Name), true, null));
+            if (!VolumeExtensions.TryGetValue(volumeFile.Extension, out var spec))
+                continue;
+
+            var architecture = DetectArchitectureFromPath(volumeFile, vmExport) ?? spec.DefaultArchitecture;
+
+            files.Add(new PackableFile(volumeFile.FullName, volumeFile.Name,
+                GeneType.Volume,
+                architecture,
+                Path.GetFileNameWithoutExtension(volumeFile.Name), spec.Compression, null));
         }
-        
+
+        // When the user supplies catlet.yaml, it is the source of truth for drives.
+        // Only the legacy vm.json / no-config path gets drives auto-derived from the volume scan.
+        if (catletFromYaml is null)
+            MergeDrivesFromVolumes(vmPlan, files);
+
         return (vmPlan, files);
 
     }
 
-
-
-    public static DirectoryInfo FindExportRootDir(DirectoryInfo vmExport)
+    private static string? DetectArchitectureFromPath(FileInfo file, DirectoryInfo root)
     {
-        // to make sure that we consider also if vm.json is in the parent directory
-        var parent = vmExport.Parent;
-        if(parent==null)
-            return vmExport;
+        var dir = file.Directory;
+        if (dir == null || PathsEqual(dir.FullName, root.FullName))
+            return null;
 
-        var vmFiles = parent.GetFiles("vm.json", SearchOption.AllDirectories);
-        var metadataFiles = parent.GetFiles("metadata.json", SearchOption.AllDirectories);
+        // <hypervisor>/<processor>/<file>
+        var processor = ProcessorTypes.KnownNames.FirstOrDefault(p =>
+            string.Equals(p, dir.Name, StringComparison.OrdinalIgnoreCase));
+        if (processor is not null)
+        {
+            var hypervisorDir = dir.Parent;
+            var hypervisor = hypervisorDir is null
+                ? null
+                : Hypervisors.KnownNames.FirstOrDefault(h =>
+                    string.Equals(h, hypervisorDir.Name, StringComparison.OrdinalIgnoreCase));
+            if (hypervisor is not null)
+                return $"{hypervisor}/{processor}";
+        }
 
-        if (vmFiles.Length > 0 || metadataFiles.Length > 0)
-            return parent;
+        // <hypervisor>/<file>
+        var directHypervisor = Hypervisors.KnownNames.FirstOrDefault(h =>
+            string.Equals(h, dir.Name, StringComparison.OrdinalIgnoreCase));
+        if (directHypervisor is not null)
+            return $"{directHypervisor}/any";
 
-        return vmExport;
+        return null;
     }
+
+    private static bool PathsEqual(string a, string b) =>
+        string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(a)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(b)),
+            StringComparison.OrdinalIgnoreCase);
+
+    private static void MergeDrivesFromVolumes(CatletConfig config, IEnumerable<PackableFile> files)
+    {
+        var existingDriveNames = (config.Drives ?? [])
+            .Select(d => d.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var newDrives = files
+            .Where(f => f.GeneType == GeneType.Volume)
+            .Select(f => f.GeneName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(name => !existingDriveNames.Contains(name))
+            .Select(name => new CatletDriveConfig { Name = name })
+            .ToArray();
+
+        if (newDrives.Length == 0)
+            return;
+
+        config.Drives = (config.Drives ?? []).Concat(newDrives).ToArray();
+    }
+
+    private static CatletConfig? ReadCatletConfig(DirectoryInfo vmExport)
+    {
+        var catletFile = vmExport.GetFiles("catlet.yaml", SearchOption.AllDirectories).FirstOrDefault();
+        if (catletFile == null)
+            return null;
+
+        try
+        {
+            var content = File.ReadAllText(catletFile.FullName).Trim().Replace("\r\n", "\n");
+            return CatletConfigYamlSerializer.Deserialize(content);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Failed to read catlet.yaml file '{catletFile.FullName}'", ex);
+        }
+    }
+
+
 
     public static void ReadMetadata(DirectoryInfo vmExport, GenesetTagInfo genesetTag)
     {

--- a/src/Eryph.GenePool.Packing/VMExport.cs
+++ b/src/Eryph.GenePool.Packing/VMExport.cs
@@ -8,8 +8,8 @@ namespace Eryph.GenePool.Packing;
 
 public static class VMExport
 {
-    private static readonly Dictionary<string, (string DefaultArchitecture, GeneCompression Compression)>
-        VolumeExtensions = new(StringComparer.OrdinalIgnoreCase)
+    public static readonly IReadOnlyDictionary<string, (string DefaultArchitecture, GeneCompression Compression)>
+        VolumeExtensions = new Dictionary<string, (string DefaultArchitecture, GeneCompression Compression)>(StringComparer.OrdinalIgnoreCase)
         {
             [".vhdx"] = (Architectures.HyperVAmd64, GeneCompression.Extreme),
             [".vhd"]  = (Architectures.HyperVAmd64, GeneCompression.Extreme),

--- a/src/apps/src/eryph-packer/Program.cs
+++ b/src/apps/src/eryph-packer/Program.cs
@@ -289,13 +289,15 @@ addVolumeCommand.SetHandler(async context =>
     var volumeFile = context.ParseResult.GetValueForArgument(filePathArgument);
     var architectureOverride = context.ParseResult.GetValueForOption(architectureOption);
 
-    var (defaultArchitecture, compression) = Path.GetExtension(volumeFile.Name).ToLowerInvariant() switch
+    var extension = Path.GetExtension(volumeFile.Name).ToLowerInvariant();
+    if (!VMExport.VolumeExtensions.TryGetValue(extension, out var volumeExtension))
     {
-        ".vhdx" or ".vhd" => (Architectures.HyperVAmd64, GeneCompression.Extreme),
-        ".qcow2" => (Architectures.KvmAmd64, GeneCompression.None),
-        var ext => throw new EryphPackerUserException(
-            $"Unsupported volume file type '{ext}'. Supported types are '.vhdx', '.vhd' and '.qcow2'.")
-    };
+        var supportedTypes = string.Join(", ", VMExport.VolumeExtensions.Keys);
+        throw new EryphPackerUserException(
+            $"Unsupported volume file type '{extension}'. Supported types are {supportedTypes}.");
+    }
+
+    var (defaultArchitecture, compression) = volumeExtension;
 
     var architecture = !string.IsNullOrWhiteSpace(architectureOverride)
         ? architectureOverride

--- a/src/apps/src/eryph-packer/Program.cs
+++ b/src/apps/src/eryph-packer/Program.cs
@@ -120,9 +120,15 @@ addVMCommand.AddArgument(genesetArgument);
 addVMCommand.AddArgument(vmExportArgument);
 genesetTagCommand.AddCommand(addVMCommand);
 
+var architectureOption = new System.CommandLine.Option<string>(
+    new[] { "--architecture", "--arch" },
+    "overrides the detected architecture (e.g. azure/amd64, ec2/amd64)");
+architectureOption.AddValidation(ManifestValidations.ValidateArchitecture);
+
 var addVolumeCommand = new Command("add-volume", "This command adds a volume reference to the geneset tag.");
 addVolumeCommand.AddArgument(genesetArgument);
 addVolumeCommand.AddArgument(filePathArgument);
+addVolumeCommand.AddOption(architectureOption);
 genesetTagCommand.AddCommand(addVolumeCommand);
 
 
@@ -243,11 +249,13 @@ addVMCommand.SetHandler(async context =>
     var genesetTagInfo = PrepareGeneSetTagCommand(context);
     var vmExportDir = context.ParseResult.GetValueForArgument(vmExportArgument);
 
-    // find the root of the exported vm
-    vmExportDir = VMExport.FindExportRootDir(vmExportDir);
-
-
     var absolutePackPath = Path.GetFullPath(genesetTagInfo.GetGenesetPath());
+
+    var hasCatletYaml = vmExportDir.GetFiles("catlet.yaml", SearchOption.AllDirectories).Any();
+    var hasVmJson = vmExportDir.GetFiles("vm.json", SearchOption.AllDirectories).Any();
+    if (hasCatletYaml && hasVmJson)
+        AnsiConsole.MarkupLine("[yellow]Both catlet.yaml and vm.json are present in the import directory — using catlet.yaml, ignoring vm.json.[/]");
+
     var (config, packableFiles) = VMExport.ExportToPackable(vmExportDir, token);
     VMExport.ReadMetadata(vmExportDir, genesetTagInfo);
 
@@ -269,7 +277,45 @@ addVMCommand.SetHandler(async context =>
 
     ResetPackableFolder(absolutePackPath);
     WritePackableFiles(packableFiles, absolutePackPath);
-    
+
+    WriteJson(genesetTagInfo.ToString());
+});
+
+// add volume command
+// ------------------------------
+addVolumeCommand.SetHandler(async context =>
+{
+    var genesetTagInfo = PrepareGeneSetTagCommand(context);
+    var volumeFile = context.ParseResult.GetValueForArgument(filePathArgument);
+    var architectureOverride = context.ParseResult.GetValueForOption(architectureOption);
+
+    var (defaultArchitecture, compression) = Path.GetExtension(volumeFile.Name).ToLowerInvariant() switch
+    {
+        ".vhdx" or ".vhd" => (Architectures.HyperVAmd64, GeneCompression.Extreme),
+        ".qcow2" => (Architectures.KvmAmd64, GeneCompression.None),
+        var ext => throw new EryphPackerUserException(
+            $"Unsupported volume file type '{ext}'. Supported types are '.vhdx', '.vhd' and '.qcow2'.")
+    };
+
+    var architecture = !string.IsNullOrWhiteSpace(architectureOverride)
+        ? architectureOverride
+        : defaultArchitecture;
+
+    var absolutePackPath = Path.GetFullPath(genesetTagInfo.GetGenesetPath());
+    var packableFiles = await ReadPackableFiles(absolutePackPath);
+
+    var geneName = Path.GetFileNameWithoutExtension(volumeFile.Name);
+    packableFiles.RemoveAll(p => p.GeneType == GeneType.Volume
+                                 && string.Equals(p.GeneName, geneName, StringComparison.OrdinalIgnoreCase)
+                                 && string.Equals(p.Architecture, architecture, StringComparison.OrdinalIgnoreCase));
+
+    packableFiles.Add(new PackableFile(volumeFile.FullName, volumeFile.Name,
+        GeneType.Volume,
+        architecture,
+        geneName, compression, null));
+
+    WritePackableFiles(packableFiles, absolutePackPath);
+
     WriteJson(genesetTagInfo.ToString());
 });
 
@@ -322,7 +368,7 @@ packCommand.SetHandler(async context =>
                 packableFiles.Add(new PackableFile(Path.Combine(packFolder, "catlet.json"),
                     "catlet.json", GeneType.Catlet,
                     Architectures.Any, // catlet is architecture independent
-                    "catlet", false, catletContent));
+                    "catlet", GeneCompression.Default, catletContent));
                 parent = catletConfig.Parent;
             }
 
@@ -337,23 +383,27 @@ packCommand.SetHandler(async context =>
                 await AddFodderFromDirectory(fodderDir, Architectures.Any);
                 foreach (var hypervisorDir in fodderDir.GetDirectories())
                 {
-                    if (string.Equals(hypervisorDir.Name, Hypervisors.HyperV, StringComparison.OrdinalIgnoreCase))
-                    {
-                        await AddFodderFromDirectory(hypervisorDir, Architectures.HyperVAny);
-
-                        foreach (var processorDir  in hypervisorDir.GetDirectories())
-                        {
-                            if (string.Equals(processorDir.Name, ProcessorTypes.Amd64,
-                                    StringComparison.OrdinalIgnoreCase))
-                                await AddFodderFromDirectory(processorDir, Architectures.HyperVAmd64);
-                            else
-                                AnsiConsole.MarkupLine($"Fodder dir contains [yellow]unknown processor type name '{processorDir.Name}'[/]");
-                        }
-                    }
-                    else
+                    var hypervisor = Hypervisors.KnownNames.FirstOrDefault(h =>
+                        string.Equals(hypervisorDir.Name, h, StringComparison.OrdinalIgnoreCase));
+                    if (hypervisor is null)
                     {
                         AnsiConsole.MarkupLine($"Fodder dir contains [yellow]unknown hypervisor name '{hypervisorDir.Name}'[/]");
+                        continue;
+                    }
 
+                    await AddFodderFromDirectory(hypervisorDir, $"{hypervisor}/any");
+
+                    foreach (var processorDir in hypervisorDir.GetDirectories())
+                    {
+                        var processor = ProcessorTypes.KnownNames.FirstOrDefault(p =>
+                            string.Equals(processorDir.Name, p, StringComparison.OrdinalIgnoreCase));
+                        if (processor is null)
+                        {
+                            AnsiConsole.MarkupLine($"Fodder dir contains [yellow]unknown processor type name '{processorDir.Name}'[/]");
+                            continue;
+                        }
+
+                        await AddFodderFromDirectory(processorDir, $"{hypervisor}/{processor}");
                     }
                 }
             }
@@ -435,7 +485,7 @@ packCommand.SetHandler(async context =>
                     packableFiles.Add(new PackableFile(fodderJsonFile,
                         $"{fodderConfig.Name}.json", GeneType.Fodder,
                         architecture,
-                        fodderConfig.Name!, false, fodderContent));
+                        fodderConfig.Name!, GeneCompression.Default, fodderContent));
                 }
             }
 

--- a/test/Eryph.GenePool.Model.Tests/ManifestValidationsTests.cs
+++ b/test/Eryph.GenePool.Model.Tests/ManifestValidationsTests.cs
@@ -210,6 +210,32 @@ public class ManifestValidationsTests
     }
 
     [Fact]
+    public void ValidateCloudCompatibility_NullEntryArray_ReturnsFail()
+    {
+        var cloudCompatibility = new Dictionary<string, CloudImageReference[]>
+        {
+            ["sda"] = null!,
+        };
+
+        var result = ManifestValidations.ValidateCloudCompatibility(cloudCompatibility, "cloud_compatibility");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
+    public void ValidateCloudCompatibility_NullEntry_ReturnsFail()
+    {
+        var cloudCompatibility = new Dictionary<string, CloudImageReference[]>
+        {
+            ["sda"] = [null!],
+        };
+
+        var result = ManifestValidations.ValidateCloudCompatibility(cloudCompatibility, "cloud_compatibility");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
     public void ValidateGenesetManifest_WithCloudCompatibility_ReturnsSuccess()
     {
         var manifest = new GenesetManifestData

--- a/test/Eryph.GenePool.Model.Tests/ManifestValidationsTests.cs
+++ b/test/Eryph.GenePool.Model.Tests/ManifestValidationsTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using FluentAssertions.LanguageExt;
 
@@ -32,5 +33,255 @@ public class ManifestValidationsTests
         var result = ManifestValidations.ValidateArchitecture(value);
 
         result.Should().BeFail();
+    }
+
+    private static CloudImageReference AzureMarketplaceReference() => new()
+    {
+        Cloud = Hypervisors.Azure,
+        Type = CloudImageReferenceTypes.AzureMarketplace,
+        Publisher = "MicrosoftWindowsServer",
+        Offer = "WindowsServer",
+        Sku = "2022-datacenter-g2",
+        Version = "latest",
+        GuestServicesInjection = GuestServicesInjectionMethods.Extension,
+    };
+
+    private static CloudImageReference Ec2SsmReference() => new()
+    {
+        Cloud = Hypervisors.EC2,
+        Type = CloudImageReferenceTypes.Ec2SsmParameter,
+        Parameter = "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+        GuestServicesInjection = GuestServicesInjectionMethods.Geneset,
+    };
+
+    private static CloudImageReference Ec2FilterReference() => new()
+    {
+        Cloud = Hypervisors.EC2,
+        Type = CloudImageReferenceTypes.Ec2ImageFilter,
+        Owner = "amazon",
+        NamePattern = "Windows_Server-2022-English-Full-Base-*",
+        GuestServicesInjection = GuestServicesInjectionMethods.Geneset,
+    };
+
+    [Fact]
+    public void ValidateCloudImageReference_ValidAzureMarketplace_ReturnsSuccess()
+    {
+        var result = ManifestValidations.ValidateCloudImageReference(AzureMarketplaceReference(), "");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_ValidEc2SsmParameter_ReturnsSuccess()
+    {
+        var result = ManifestValidations.ValidateCloudImageReference(Ec2SsmReference(), "");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_ValidEc2ImageFilter_ReturnsSuccess()
+    {
+        var result = ManifestValidations.ValidateCloudImageReference(Ec2FilterReference(), "");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_MissingRequiredField_ReturnsFail()
+    {
+        var reference = AzureMarketplaceReference();
+        reference.Sku = null;
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_UnknownCloud_ReturnsFail()
+    {
+        var reference = AzureMarketplaceReference();
+        reference.Cloud = "gcp";
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_UnknownType_ReturnsFail()
+    {
+        var reference = AzureMarketplaceReference();
+        reference.Type = "azure-shared-gallery";
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_CloudTypeMismatch_ReturnsFail()
+    {
+        var reference = Ec2SsmReference();
+        reference.Cloud = Hypervisors.Azure;
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeFail();
+    }
+
+    [Theory]
+    [InlineData(GuestServicesInjectionMethods.Extension)]
+    [InlineData(GuestServicesInjectionMethods.Geneset)]
+    [InlineData(GuestServicesInjectionMethods.None)]
+    public void ValidateCloudImageReference_KnownGuestServicesInjection_ReturnsSuccess(string method)
+    {
+        var reference = AzureMarketplaceReference();
+        reference.GuestServicesInjection = method;
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_UnknownGuestServicesInjection_ReturnsFail()
+    {
+        var reference = AzureMarketplaceReference();
+        reference.GuestServicesInjection = "manual";
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_ValidAzurePlan_ReturnsSuccess()
+    {
+        var reference = AzureMarketplaceReference();
+        reference.Plan = new AzurePlan
+        {
+            Publisher = "vendor",
+            Product = "vendor-product",
+            Name = "byol",
+        };
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateCloudImageReference_IncompleteAzurePlan_ReturnsFail()
+    {
+        var reference = AzureMarketplaceReference();
+        reference.Plan = new AzurePlan
+        {
+            Publisher = "vendor",
+            // product missing
+            Name = "byol",
+        };
+
+        var result = ManifestValidations.ValidateCloudImageReference(reference, "");
+
+        result.Should().BeFail();
+    }
+
+    [Fact]
+    public void ValidateCloudCompatibility_Null_ReturnsSuccess()
+    {
+        var result = ManifestValidations.ValidateCloudCompatibility(null, "cloud_compatibility");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateCloudCompatibility_ValidMap_ReturnsSuccess()
+    {
+        var cloudCompatibility = new Dictionary<string, CloudImageReference[]>
+        {
+            ["sda"] = [AzureMarketplaceReference(), Ec2SsmReference(), Ec2FilterReference()],
+        };
+
+        var result = ManifestValidations.ValidateCloudCompatibility(cloudCompatibility, "cloud_compatibility");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateGenesetManifest_WithCloudCompatibility_ReturnsSuccess()
+    {
+        var manifest = new GenesetManifestData
+        {
+            Geneset = "dbosoft/winsrv2022-standard",
+            ShortDescription = "Windows Server 2022 Standard",
+            CloudCompatibility = new Dictionary<string, CloudImageReference[]>
+            {
+                ["sda"] = [AzureMarketplaceReference(), Ec2SsmReference()],
+            },
+        };
+
+        var result = ManifestValidations.ValidateGenesetManifest(manifest);
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void GenesetManifest_WithCloudCompatibility_RoundTripsThroughJson()
+    {
+        const string json = """
+            {
+              "geneset": "dbosoft/winsrv2022-standard",
+              "public": true,
+              "short_description": "Windows Server 2022 Standard",
+              "cloud_compatibility": {
+                "sda": [
+                  {
+                    "cloud": "azure",
+                    "type": "azure_marketplace",
+                    "publisher": "MicrosoftWindowsServer",
+                    "offer": "WindowsServer",
+                    "sku": "2022-datacenter-g2",
+                    "version": "latest",
+                    "guest_services_injection": "extension"
+                  },
+                  {
+                    "cloud": "ec2",
+                    "type": "ec2_ssm_parameter",
+                    "parameter": "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+                    "guest_services_injection": "geneset"
+                  },
+                  {
+                    "cloud": "ec2",
+                    "type": "ec2_image_filter",
+                    "owner": "amazon",
+                    "name_pattern": "Windows_Server-2022-English-Full-Base-*",
+                    "guest_services_injection": "geneset"
+                  }
+                ]
+              }
+            }
+            """;
+
+        var manifest = JsonSerializer.Deserialize<GenesetManifestData>(
+            json, GeneModelDefaults.SerializerOptions);
+
+        manifest.Should().NotBeNull();
+        manifest!.CloudCompatibility.Should().ContainKey("sda");
+        var entries = manifest.CloudCompatibility!["sda"];
+        entries.Should().HaveCount(3);
+        entries[0].Type.Should().Be(CloudImageReferenceTypes.AzureMarketplace);
+        entries[0].Sku.Should().Be("2022-datacenter-g2");
+        entries[0].GuestServicesInjection.Should().Be(GuestServicesInjectionMethods.Extension);
+        entries[1].Parameter.Should().NotBeNullOrEmpty();
+        entries[2].NamePattern.Should().Be("Windows_Server-2022-English-Full-Base-*");
+
+        ManifestValidations.ValidateGenesetManifest(manifest).Should().BeSuccess();
+
+        // serialize back and confirm snake_case property names are preserved
+        var serialized = JsonSerializer.Serialize(manifest, GeneModelDefaults.SerializerOptions);
+        serialized.Should().Contain("\"guest_services_injection\"");
+        serialized.Should().Contain("\"name_pattern\"");
     }
 }

--- a/test/Eryph.GenePool.Model.Tests/ManifestValidationsTests.cs
+++ b/test/Eryph.GenePool.Model.Tests/ManifestValidationsTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using FluentAssertions.LanguageExt;
+
+namespace Eryph.GenePool.Model.Tests;
+
+public class ManifestValidationsTests
+{
+    [Theory]
+    [InlineData(Architectures.HyperVAmd64)]
+    [InlineData(Architectures.HyperVAny)]
+    [InlineData(Architectures.KvmAmd64)]
+    [InlineData(Architectures.KvmAny)]
+    [InlineData(Architectures.AzureAmd64)]
+    [InlineData(Architectures.AzureAny)]
+    [InlineData(Architectures.EC2Amd64)]
+    [InlineData(Architectures.EC2Any)]
+    [InlineData(Architectures.Any)]
+    public void ValidateArchitecture_KnownValue_ReturnsSuccess(string value)
+    {
+        var result = ManifestValidations.ValidateArchitecture(value);
+
+        result.Should().BeSuccess();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("kvm")]
+    [InlineData("hyperv/arm64")]
+    [InlineData("xen/amd64")]
+    public void ValidateArchitecture_UnknownValue_ReturnsFail(string value)
+    {
+        var result = ManifestValidations.ValidateArchitecture(value);
+
+        result.Should().BeFail();
+    }
+}

--- a/test/Eryph.GenePool.Packing.Tests/GenePackerTests.cs
+++ b/test/Eryph.GenePool.Packing.Tests/GenePackerTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Eryph.GenePool.Model;
+
+namespace Eryph.GenePool.Packing.Tests;
+
+public sealed class GenePackerTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public GenePackerTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_workDir);
+    }
+
+    [Fact]
+    public async Task CreateGene_CompressionNone_WritesPlainFormatEvenForLargeFile()
+    {
+        var sourcePath = Path.Combine(_workDir, "volume.qcow2");
+        await File.WriteAllBytesAsync(sourcePath, new byte[GeneModelDefaults.MinCompressionBytes * 2]);
+
+        var packable = new PackableFile(sourcePath, "volume.qcow2",
+            GeneType.Volume, Architectures.KvmAmd64,
+            "volume", GeneCompression.None, null);
+
+        var hashRef = await GenePacker.CreateGene(packable, _workDir);
+
+        var manifest = ReadManifest(hashRef);
+        manifest.Format.Should().Be("plain");
+    }
+
+    [Fact]
+    public async Task CreateGene_CompressionExtreme_WritesXzFormat()
+    {
+        var sourcePath = Path.Combine(_workDir, "volume.vhdx");
+        await File.WriteAllBytesAsync(sourcePath, new byte[GeneModelDefaults.MinCompressionBytes * 2]);
+
+        var packable = new PackableFile(sourcePath, "volume.vhdx",
+            GeneType.Volume, Architectures.HyperVAmd64,
+            "volume", GeneCompression.Extreme, null);
+
+        var hashRef = await GenePacker.CreateGene(packable, _workDir);
+
+        var manifest = ReadManifest(hashRef);
+        manifest.Format.Should().Be("xz");
+    }
+
+    [Fact]
+    public async Task CreateGene_CompressionDefault_LargeFile_WritesGzFormat()
+    {
+        var sourcePath = Path.Combine(_workDir, "catlet.json");
+        await File.WriteAllBytesAsync(sourcePath, new byte[GeneModelDefaults.MinCompressionBytes * 2]);
+
+        var packable = new PackableFile(sourcePath, "catlet.json",
+            GeneType.Catlet, Architectures.Any,
+            "catlet", GeneCompression.Default, null);
+
+        var hashRef = await GenePacker.CreateGene(packable, _workDir);
+
+        var manifest = ReadManifest(hashRef);
+        manifest.Format.Should().Be("gz");
+    }
+
+    private GeneManifestData ReadManifest(string hashRef)
+    {
+        var hash = hashRef.Split(':')[1];
+        var manifestPath = Path.Combine(_workDir, hash, "gene.json");
+        var json = File.ReadAllText(manifestPath);
+        return JsonSerializer.Deserialize<GeneManifestData>(json, GeneModelDefaults.SerializerOptions)!;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir))
+            Directory.Delete(_workDir, true);
+    }
+}

--- a/test/Eryph.GenePool.Packing.Tests/VMExportTests.cs
+++ b/test/Eryph.GenePool.Packing.Tests/VMExportTests.cs
@@ -1,0 +1,162 @@
+using Eryph.GenePool.Model;
+
+namespace Eryph.GenePool.Packing.Tests;
+
+public sealed class VMExportTests : IDisposable
+{
+    private readonly DirectoryInfo _exportDir;
+
+    public VMExportTests()
+    {
+        _exportDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        _exportDir.Create();
+    }
+
+    [Fact]
+    public void ExportToPackable_VhdxFile_ReturnsHyperVVolumeWithExtremeCompression()
+    {
+        var vhdxPath = Path.Combine(_exportDir.FullName, "sda.vhdx");
+        File.WriteAllBytes(vhdxPath, [1, 2, 3]);
+
+        var (_, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        files.Should().ContainSingle(f => f.FileName == "sda.vhdx")
+            .Which.Should().BeEquivalentTo(new
+            {
+                GeneType = GeneType.Volume,
+                Architecture = Architectures.HyperVAmd64,
+                GeneName = "sda",
+                Compression = GeneCompression.Extreme,
+            });
+    }
+
+    [Fact]
+    public void ExportToPackable_Qcow2File_ReturnsKvmVolumeWithoutCompression()
+    {
+        var qcow2Path = Path.Combine(_exportDir.FullName, "sda.qcow2");
+        File.WriteAllBytes(qcow2Path, [1, 2, 3]);
+
+        var (_, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        files.Should().ContainSingle(f => f.FileName == "sda.qcow2")
+            .Which.Should().BeEquivalentTo(new
+            {
+                GeneType = GeneType.Volume,
+                Architecture = Architectures.KvmAmd64,
+                GeneName = "sda",
+                Compression = GeneCompression.None,
+            });
+    }
+
+    [Fact]
+    public void ExportToPackable_MixedFiles_ReturnsBothArchitectures()
+    {
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sda.vhdx"), [1, 2, 3]);
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sdb.qcow2"), [4, 5, 6]);
+
+        var (_, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        var fileList = files.ToList();
+        fileList.Should().HaveCount(2);
+        fileList.Should().Contain(f => f.Architecture == Architectures.HyperVAmd64 && f.Compression == GeneCompression.Extreme);
+        fileList.Should().Contain(f => f.Architecture == Architectures.KvmAmd64 && f.Compression == GeneCompression.None);
+    }
+
+    [Fact]
+    public void ExportToPackable_VolumesScanned_AppendsDrivesByGeneName()
+    {
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sda.vhdx"), [1, 2, 3]);
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sda.qcow2"), [1, 2, 3]);
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sdb.qcow2"), [4, 5, 6]);
+
+        var (config, _) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        config!.Drives.Should().NotBeNull();
+        config.Drives!.Select(d => d.Name).Should().BeEquivalentTo("sda", "sdb");
+    }
+
+    [Fact]
+    public void ExportToPackable_CatletYamlPresent_UsesItOverVmJson()
+    {
+        File.WriteAllText(Path.Combine(_exportDir.FullName, "catlet.yaml"),
+            "cpu:\n  count: 4\nmemory:\n  startup: 4096\n");
+        File.WriteAllText(Path.Combine(_exportDir.FullName, "vm.json"),
+            "{\"vm\":{\"ProcessorCount\":1,\"MemoryStartup\":1073741824}}");
+
+        var (config, _) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        config!.Cpu!.Count.Should().Be(4);
+        config.Memory!.Startup.Should().Be(4096);
+    }
+
+    [Fact]
+    public void ExportToPackable_VhdFile_TreatedLikeVhdx()
+    {
+        var vhdPath = Path.Combine(_exportDir.FullName, "sda.vhd");
+        File.WriteAllBytes(vhdPath, [1, 2, 3]);
+
+        var (_, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        files.Should().ContainSingle(f => f.FileName == "sda.vhd")
+            .Which.Should().BeEquivalentTo(new
+            {
+                Architecture = Architectures.HyperVAmd64,
+                Compression = GeneCompression.Extreme,
+            });
+    }
+
+    [Fact]
+    public void ExportToPackable_FilesInHypervisorProcessorFolders_UseFolderArchitecture()
+    {
+        var hyperv = Directory.CreateDirectory(Path.Combine(_exportDir.FullName, "hyperv", "amd64"));
+        var kvm = Directory.CreateDirectory(Path.Combine(_exportDir.FullName, "kvm", "amd64"));
+        var azure = Directory.CreateDirectory(Path.Combine(_exportDir.FullName, "azure", "amd64"));
+        File.WriteAllBytes(Path.Combine(hyperv.FullName, "sda.vhdx"), [1]);
+        File.WriteAllBytes(Path.Combine(kvm.FullName, "sda.qcow2"), [1]);
+        File.WriteAllBytes(Path.Combine(azure.FullName, "sda.vhd"), [1]);
+
+        var (_, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        var fileList = files.ToList();
+        fileList.Should().Contain(f => f.FileName == "sda.vhdx" && f.Architecture == Architectures.HyperVAmd64);
+        fileList.Should().Contain(f => f.FileName == "sda.qcow2" && f.Architecture == Architectures.KvmAmd64);
+        fileList.Should().Contain(f => f.FileName == "sda.vhd" && f.Architecture == Architectures.AzureAmd64
+                                       && f.Compression == GeneCompression.Extreme);
+    }
+
+    [Fact]
+    public void ExportToPackable_FileInHypervisorFolderWithoutProcessor_UsesAnyArchitecture()
+    {
+        var kvmDir = Directory.CreateDirectory(Path.Combine(_exportDir.FullName, "kvm"));
+        File.WriteAllBytes(Path.Combine(kvmDir.FullName, "sda.qcow2"), [1]);
+
+        var (_, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        files.Should().ContainSingle()
+            .Which.Architecture.Should().Be(Architectures.KvmAny);
+    }
+
+    [Fact]
+    public void ExportToPackable_CatletYamlPresent_DrivesNotAutoMergedFromScan()
+    {
+        File.WriteAllText(Path.Combine(_exportDir.FullName, "catlet.yaml"),
+            "drives:\n- name: sda\n  size: 50\n");
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sda.qcow2"), [1, 2, 3]);
+        File.WriteAllBytes(Path.Combine(_exportDir.FullName, "sdb.qcow2"), [4, 5, 6]);
+
+        var (config, files) = VMExport.ExportToPackable(_exportDir, CancellationToken.None);
+
+        // catlet.yaml is authoritative for drives: sdb on disk must NOT be added
+        config!.Drives.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new { Name = "sda", Size = 50 });
+
+        // ...but the volume files themselves are still packed (sdb becomes an orphan gene)
+        files.Should().HaveCount(2);
+    }
+
+    public void Dispose()
+    {
+        if (_exportDir.Exists)
+            _exportDir.Delete(true);
+    }
+}


### PR DESCRIPTION
Opens the packer to non-Hyper-V build pipelines.

- New architectures `kvm/amd64`, `azure/amd64`, `ec2/amd64` (+ `/any` variants), with `Hypervisors.KnownNames` / `ProcessorTypes.KnownNames` as the single source of truth used by validation, fodder folder walking, and the new volume folder detection.
- `ExtremeCompression: bool` on `PackableFile` replaced with `GeneCompression { Default, Extreme, None }` so qcow2 (already precompressed) is packed as `plain` instead of being re-compressed with gzip.
- `add-vm` now accepts a neutral `catlet.yaml` alongside `metadata.json` and the volume files, falling back to the existing `vm.json` (Hyper-V) path when no catlet.yaml is present; a yellow warning is emitted when both are found. Volume architecture is detected from `<hypervisor>[/<processor>]/` subfolders (matching the fodder layout); flat layouts keep working via extension-based defaults. `.vhd` is accepted alongside `.vhdx`. When the legacy vm.json (or no config) path is used, missing drives are auto-derived from the volume scan; `catlet.yaml` stays authoritative when supplied.
- The recursive `FindExportRootDir` parent-walk is removed — it was vacuuming up sibling exports.
- `add-volume` actually has a handler now (was a declared no-op), with a `--architecture` override for platform-specific use cases. fixes #1 