### PR TITLE
Expose geneset manifest version and cloud_compatibility in model API

### DIFF
--- a/src/Eryph.GenePool.Client/GenesetClient.cs
+++ b/src/Eryph.GenePool.Client/GenesetClient.cs
@@ -7,6 +7,7 @@ using Eryph.ConfigModel;
 using Eryph.GenePool.Client.Internal;
 using Eryph.GenePool.Client.Requests;
 using Eryph.GenePool.Client.RestClients;
+using Eryph.GenePool.Model;
 using Eryph.GenePool.Model.Requests.Genesets;
 using Eryph.GenePool.Model.Responses;
 
@@ -235,6 +236,8 @@ public class GenesetClient
         string? description = default,
         string? descriptionMarkdown = default,
         IDictionary<string,string>? metadata = default,
+        string? version = default,
+        IDictionary<string, CloudImageReference[]>? cloudCompatibility = default,
         RequestOptions? options = default,
         CancellationToken cancellationToken = default)
     {
@@ -249,7 +252,9 @@ public class GenesetClient
                 ShortDescription = shortDescription,
                 Description = description,
                 DescriptionMarkdown = descriptionMarkdown,
-                Metadata = metadata
+                Metadata = metadata,
+                Version = version,
+                CloudCompatibility = cloudCompatibility
             };
 
             return (await RestClient.CreateAsync(body,
@@ -270,6 +275,8 @@ public class GenesetClient
         string? descriptionMarkdown = default,
         IDictionary<string, string>? metadata = default,
         string? etag = default,
+        string? version = default,
+        IDictionary<string, CloudImageReference[]>? cloudCompatibility = default,
         RequestOptions? options = default,
         CancellationToken cancellationToken = default)
     {
@@ -285,7 +292,9 @@ public class GenesetClient
                 Description = description,
                 DescriptionMarkdown = descriptionMarkdown,
                 Metadata = metadata,
-                ETag = etag
+                ETag = etag,
+                Version = version,
+                CloudCompatibility = cloudCompatibility
             };
 
             return (await RestClient.UpdateAsync(_organization, _geneset, body,
@@ -309,6 +318,8 @@ public class GenesetClient
         string? descriptionMarkdown = default,
         IDictionary<string, string>? metadata = default,
         string? etag = default,
+        string? version = default,
+        IDictionary<string, CloudImageReference[]>? cloudCompatibility = default,
         RequestOptions? options = default,
         CancellationToken cancellationToken = default)
     {
@@ -323,7 +334,9 @@ public class GenesetClient
                 Description = description,
                 DescriptionMarkdown = descriptionMarkdown,
                 Metadata = metadata,
-                ETag = etag
+                ETag = etag,
+                Version = version,
+                CloudCompatibility = cloudCompatibility
             };
             return RestClient.Update(_organization, _geneset, body,
                 options ?? new RequestOptions(),
@@ -344,6 +357,8 @@ public class GenesetClient
         string? description = default,
         string? descriptionMarkdown = default,
         IDictionary<string, string>? metadata = default,
+        string? version = default,
+        IDictionary<string, CloudImageReference[]>? cloudCompatibility = default,
         RequestOptions? options = default,
         CancellationToken cancellationToken = default)
     {
@@ -358,7 +373,9 @@ public class GenesetClient
                 ShortDescription = shortDescription,
                 Description = description,
                 DescriptionMarkdown = descriptionMarkdown,
-                Metadata = metadata
+                Metadata = metadata,
+                Version = version,
+                CloudCompatibility = cloudCompatibility
             };
             return RestClient.Create(body,
                 options?? new RequestOptions(),

--- a/src/Eryph.GenePool.Model/Requests/Genesets/GenesetUpdateRequestBody.cs
+++ b/src/Eryph.GenePool.Model/Requests/Genesets/GenesetUpdateRequestBody.cs
@@ -5,6 +5,13 @@ namespace Eryph.GenePool.Model.Requests.Genesets;
 
 public class GenesetUpdateRequestBody
 {
+    /// <summary>
+    /// The geneset manifest version the client understands. The server respects
+    /// this when saving the manifest, so a client never writes fields from a
+    /// newer manifest version than it declares here.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
 
     [JsonPropertyName("short_description")]
 
@@ -24,6 +31,9 @@ public class GenesetUpdateRequestBody
 
     [JsonPropertyName("metadata")]
     public IDictionary<string, string>? Metadata { get; set; }
+
+    [JsonPropertyName("cloud_compatibility")]
+    public IDictionary<string, CloudImageReference[]>? CloudCompatibility { get; set; }
 
     [JsonPropertyName("etag")]
     public string? ETag { get; set; }

--- a/src/Eryph.GenePool.Model/Requests/Genesets/NewGenesetRequestBody.cs
+++ b/src/Eryph.GenePool.Model/Requests/Genesets/NewGenesetRequestBody.cs
@@ -8,6 +8,14 @@ public class NewGenesetRequestBody
     [JsonPropertyName("geneset")]
     public string? Geneset { get; set; }
 
+    /// <summary>
+    /// The geneset manifest version the client understands. The server respects
+    /// this when saving the manifest, so a client never writes fields from a
+    /// newer manifest version than it declares here.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
     [JsonPropertyName("short_description")]
 
     public string? ShortDescription { get; set; }
@@ -26,4 +34,7 @@ public class NewGenesetRequestBody
 
     [JsonPropertyName("metadata")]
     public IDictionary<string, string>? Metadata { get; set; }
+
+    [JsonPropertyName("cloud_compatibility")]
+    public IDictionary<string, CloudImageReference[]>? CloudCompatibility { get; set; }
 }

--- a/src/Eryph.GenePool.Model/Responses/GenesetResponse.cs
+++ b/src/Eryph.GenePool.Model/Responses/GenesetResponse.cs
@@ -10,6 +10,8 @@ public record GenesetResponse(
     [property: JsonPropertyName("org")] OrganizationRefResponse Org,
     [property: JsonPropertyName("geneset")]
     string Geneset,
+    [property: JsonPropertyName("version")]
+    string? Version,
     [property: JsonPropertyName("uri")] Uri? Uri,
     [property: JsonPropertyName("etag")] string? ETag,
     [property: JsonPropertyName("public")] bool Public,
@@ -23,6 +25,8 @@ public record GenesetResponse(
     Uri DescriptionUri,
     [property: JsonPropertyName("metadata")]
     IDictionary<string, string>? Metadata,
+    [property: JsonPropertyName("cloud_compatibility")]
+    IDictionary<string, CloudImageReference[]>? CloudCompatibility,
     [property: JsonPropertyName("tags_uri")]
     Uri TagsUri,
     [property: JsonPropertyName("tags")] GenesetTagResponse[]? Tags,

--- a/src/apps/src/eryph-packer/Program.cs
+++ b/src/apps/src/eryph-packer/Program.cs
@@ -910,6 +910,8 @@ async Task CreateOrUpdateGeneset(GenesetInfo genesetInfo, GenesetClient genesetC
             genesetInfo.ManifestData.Description,
             markdownContent,
             genesetInfo.ManifestData.Metadata,
+            version: genesetInfo.ManifestData.Version,
+            cloudCompatibility: genesetInfo.ManifestData.CloudCompatibility,
             cancellationToken: token
         );
     }
@@ -926,6 +928,8 @@ async Task CreateOrUpdateGeneset(GenesetInfo genesetInfo, GenesetClient genesetC
             markdownContent,
             genesetInfo.ManifestData.Metadata,
             geneset?.ETag,
+            version: genesetInfo.ManifestData.Version,
+            cloudCompatibility: genesetInfo.ManifestData.CloudCompatibility,
             cancellationToken: token
         );
     }


### PR DESCRIPTION
Commit #32 extended the geneset manifest with a `cloud_compatibility` field and bumped `LatestGenesetManifestVersion` to 1.2, but the geneset-level model API DTOs were never updated. Unlike `GenesetTagResponse` (which embeds the full manifest including its version), `GenesetResponse` flattens a fixed subset of fields and does not carry the manifest version or the new field — so clients can neither tell which manifest version a geneset uses nor read/write `cloud_compatibility`.

This wires the new data through the geneset-level contract:

- `GenesetResponse`: add `version` and `cloud_compatibility`.
- `NewGenesetRequestBody` / `GenesetUpdateRequestBody`: add `version` (the manifest version the client understands, which the server respects when saving the manifest) and `cloud_compatibility`.
- `GenesetClient` `Create`/`Update`: add `version` and `cloudCompatibility` parameters.
- `eryph-packer`: forward the manifest version and `cloud_compatibility` when creating/updating a geneset.

Note: the server that fills and persists these DTOs lives in another repo; this PR only defines the client contract.
