### PR TITLE
Expose MSAL public client builder for embedded WPF sign-in

### DIFF
--- a/docs/wpf-embedded-signin.md
+++ b/docs/wpf-embedded-signin.md
@@ -1,0 +1,65 @@
+# Embedded WebView2 sign-in for Windows desktop apps
+
+By default `B2CInteractiveBrowserCredential` opens the system's default browser to
+sign the user in. Windows desktop applications (WPF / WinForms) often prefer an
+**embedded** sign-in dialog that appears as a child window of the application
+instead.
+
+MSAL implements the embedded dialog with WebView2, which lives in the separate
+[`Microsoft.Identity.Client.Desktop`](https://www.nuget.org/packages/Microsoft.Identity.Client.Desktop)
+package. This client library targets `netstandard2.1` and therefore does **not**
+reference that package itself. Instead it exposes the underlying MSAL
+`PublicClientApplicationBuilder` so that a consuming desktop application can add
+the package and enable the feature.
+
+## 1. Add the package to your desktop app
+
+```
+dotnet add package Microsoft.Identity.Client.Desktop
+```
+
+The consuming project must target a Windows desktop TFM (for example
+`net8.0-windows`) and have `<UseWPF>true</UseWPF>` (or `<UseWindowsForms>true</UseWindowsForms>`).
+
+## 2. Configure the credential
+
+Three pieces are required to show the embedded dialog modally over your window:
+
+- `ConfigurePublicClientApplication` &ndash; call `WithWindowsEmbeddedBrowserSupport()`
+  on the exposed builder (this method comes from the `Desktop` package).
+- `BrowserCustomization.UseEmbeddedWebView = true` &ndash; select the embedded view
+  instead of the system browser.
+- `BrowserCustomization.ParentActivityOrWindow` &ndash; provide the window handle so
+  the dialog is owned by your application window.
+
+```csharp
+using System.Windows.Interop;
+using Eryph.GenePool.Client;
+using Eryph.GenePool.Client.Credentials;
+using Microsoft.Identity.Client;
+
+// window is the WPF Window that should own the sign-in dialog
+var windowHandle = new WindowInteropHelper(window).EnsureHandle();
+
+var options = new B2CInteractiveBrowserCredentialOptions
+{
+    ClientId = "<your-client-id>",
+    AuthorityUri = "<your-b2c-authority-uri>",
+
+    // Enable the embedded WebView2 dialog from the Desktop package.
+    ConfigurePublicClientApplication = builder =>
+        builder.WithWindowsEmbeddedBrowserSupport(),
+
+    BrowserCustomization = new BrowserCustomizationOptions
+    {
+        UseEmbeddedWebView = true,
+        ParentActivityOrWindow = () => windowHandle,
+    },
+};
+
+var credential = new B2CInteractiveBrowserCredential(options);
+```
+
+The credential can then be passed to `GenePoolClient` as usual. On non-Windows
+platforms simply omit `ConfigurePublicClientApplication` and leave
+`UseEmbeddedWebView` unset to keep using the system browser.

--- a/src/Eryph.GenePool.Client.Authentication/BrowserCustomizationOptions.cs
+++ b/src/Eryph.GenePool.Client.Authentication/BrowserCustomizationOptions.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 using Microsoft.Identity.Client;
 
 namespace Eryph.GenePool.Client;
@@ -14,6 +15,15 @@ public class BrowserCustomizationOptions
     /// or the system default browser
     /// </summary>
     public bool? UseEmbeddedWebView { get; set; }
+
+    /// <summary>
+    /// A callback which returns the handle of the window that should own the interactive
+    /// authentication dialog. This is required when using the embedded WebView2 dialog on a
+    /// Windows desktop (WPF/WinForms) application so that the sign-in window is displayed
+    /// modally over the application. For WPF the handle can be obtained via
+    /// <c>new WindowInteropHelper(window).Handle</c>.
+    /// </summary>
+    public Func<IntPtr>? ParentActivityOrWindow { get; set; }
 
     internal SystemWebViewOptions? SystemBrowserOptions;
 

--- a/src/Eryph.GenePool.Client.Authentication/BrowserCustomizationOptions.cs
+++ b/src/Eryph.GenePool.Client.Authentication/BrowserCustomizationOptions.cs
@@ -21,7 +21,9 @@ public class BrowserCustomizationOptions
     /// authentication dialog. This is required when using the embedded WebView2 dialog on a
     /// Windows desktop (WPF/WinForms) application so that the sign-in window is displayed
     /// modally over the application. For WPF the handle can be obtained via
-    /// <c>new WindowInteropHelper(window).Handle</c>.
+    /// <c>new WindowInteropHelper(window).EnsureHandle()</c>, which also creates the handle if
+    /// the window has not been shown yet (unlike <c>Handle</c>, which returns
+    /// <c>IntPtr.Zero</c> in that case).
     /// </summary>
     public Func<IntPtr>? ParentActivityOrWindow { get; set; }
 

--- a/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredential.cs
+++ b/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredential.cs
@@ -42,13 +42,15 @@ public class B2CInteractiveBrowserCredential : TokenCredential
         Argument.AssertNotNullOrWhiteSpace(authorityUri, nameof(authorityUri));
         Debug.Assert(authorityUri != null, nameof(authorityUri) + " != null");
 
+        var browserOptions = options as B2CInteractiveBrowserCredentialOptions;
+
         ClientId = clientId;
-        LoginHint = (options as B2CInteractiveBrowserCredentialOptions)?.LoginHint;
-        var redirectUrl = (options as B2CInteractiveBrowserCredentialOptions)?.RedirectUri?.AbsoluteUri ?? Constants.DefaultRedirectUrl;
-        var configurePublicClient = (options as B2CInteractiveBrowserCredentialOptions)?.ConfigurePublicClientApplication;
-        Client = client ?? new MsalPublicClient(authorityUri, clientId, redirectUrl, options, configurePublicClient);
-        Record = (options as B2CInteractiveBrowserCredentialOptions)?.AuthenticationRecord;
-        BrowserCustomization = (options as B2CInteractiveBrowserCredentialOptions)?.BrowserCustomization;
+        LoginHint = browserOptions?.LoginHint;
+        var redirectUrl = browserOptions?.RedirectUri?.AbsoluteUri ?? Constants.DefaultRedirectUrl;
+        Client = client ?? new MsalPublicClient(authorityUri, clientId, redirectUrl, options,
+            browserOptions?.ConfigurePublicClientApplication);
+        Record = browserOptions?.AuthenticationRecord;
+        BrowserCustomization = browserOptions?.BrowserCustomization;
     }
 
 

--- a/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredential.cs
+++ b/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredential.cs
@@ -45,7 +45,8 @@ public class B2CInteractiveBrowserCredential : TokenCredential
         ClientId = clientId;
         LoginHint = (options as B2CInteractiveBrowserCredentialOptions)?.LoginHint;
         var redirectUrl = (options as B2CInteractiveBrowserCredentialOptions)?.RedirectUri?.AbsoluteUri ?? Constants.DefaultRedirectUrl;
-        Client = client ?? new MsalPublicClient(authorityUri, clientId, redirectUrl, options);
+        var configurePublicClient = (options as B2CInteractiveBrowserCredentialOptions)?.ConfigurePublicClientApplication;
+        Client = client ?? new MsalPublicClient(authorityUri, clientId, redirectUrl, options, configurePublicClient);
         Record = (options as B2CInteractiveBrowserCredentialOptions)?.AuthenticationRecord;
         BrowserCustomization = (options as B2CInteractiveBrowserCredentialOptions)?.BrowserCustomization;
     }

--- a/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredential.cs
+++ b/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredential.cs
@@ -42,15 +42,15 @@ public class B2CInteractiveBrowserCredential : TokenCredential
         Argument.AssertNotNullOrWhiteSpace(authorityUri, nameof(authorityUri));
         Debug.Assert(authorityUri != null, nameof(authorityUri) + " != null");
 
-        var browserOptions = options as B2CInteractiveBrowserCredentialOptions;
+        var interactiveOptions = options as B2CInteractiveBrowserCredentialOptions;
 
         ClientId = clientId;
-        LoginHint = browserOptions?.LoginHint;
-        var redirectUrl = browserOptions?.RedirectUri?.AbsoluteUri ?? Constants.DefaultRedirectUrl;
+        LoginHint = interactiveOptions?.LoginHint;
+        var redirectUrl = interactiveOptions?.RedirectUri?.AbsoluteUri ?? Constants.DefaultRedirectUrl;
         Client = client ?? new MsalPublicClient(authorityUri, clientId, redirectUrl, options,
-            browserOptions?.ConfigurePublicClientApplication);
-        Record = browserOptions?.AuthenticationRecord;
-        BrowserCustomization = browserOptions?.BrowserCustomization;
+            interactiveOptions?.ConfigurePublicClientApplication);
+        Record = interactiveOptions?.AuthenticationRecord;
+        BrowserCustomization = interactiveOptions?.BrowserCustomization;
     }
 
 

--- a/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredentialOptions.cs
+++ b/src/Eryph.GenePool.Client.Authentication/Credentials/B2CInteractiveBrowserCredentialOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using Azure.Core;
+using Microsoft.Identity.Client;
 
 namespace Eryph.GenePool.Client.Credentials;
 
@@ -43,4 +44,25 @@ public class B2CInteractiveBrowserCredentialOptions : TokenCredentialOptions
     /// The options for customizing the browser for interactive authentication.
     /// </summary>
     public BrowserCustomizationOptions? BrowserCustomization { get; set; }
+
+    /// <summary>
+    /// An optional callback which is invoked with the underlying MSAL
+    /// <see cref="PublicClientApplicationBuilder"/> just before the public client application is
+    /// built. This exposes the builder so that a consuming application can apply additional
+    /// configuration which requires packages that this library does not reference itself.
+    /// </summary>
+    /// <remarks>
+    /// The most common use case is enabling the embedded WebView2 sign-in dialog for a Windows
+    /// desktop (WPF/WinForms) application. To do so, add the
+    /// <c>Microsoft.Identity.Client.Desktop</c> package to the consuming application and call
+    /// <c>WithWindowsEmbeddedBrowserSupport()</c> on the builder:
+    /// <code>
+    /// options.ConfigurePublicClientApplication = builder =>
+    ///     builder.WithWindowsEmbeddedBrowserSupport();
+    /// </code>
+    /// Combine this with <see cref="BrowserCustomizationOptions.UseEmbeddedWebView"/> set to
+    /// <c>true</c> and <see cref="BrowserCustomizationOptions.ParentActivityOrWindow"/> to show the
+    /// dialog modally over the application window.
+    /// </remarks>
+    public Action<PublicClientApplicationBuilder>? ConfigurePublicClientApplication { get; set; }
 }

--- a/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
+++ b/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
@@ -83,9 +83,7 @@ internal class MsalPublicClient(
 
         var builder = client.AcquireTokenInteractive(scopes)
             .WithPrompt(prompt)
-            .WithClaims(claims ?? "")
-            .WithPrompt(prompt)
-            .WithClaims(claims);
+            .WithClaims(claims ?? "");
         if (loginHint != null)
         {
             builder.WithLoginHint(loginHint);

--- a/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
+++ b/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 
@@ -8,10 +9,13 @@ internal class MsalPublicClient(
     string authorityUri,
     string? clientId,
     string redirectUrl,
-    TokenCredentialOptions? options)
+    TokenCredentialOptions? options,
+    Action<PublicClientApplicationBuilder>? configureBuilder = null)
     : MsalClientBase<IPublicClientApplication>(authorityUri, clientId, options?.TokenCachePersistenceOptions)
 {
     internal string RedirectUrl { get; } = redirectUrl;
+
+    private readonly Action<PublicClientApplicationBuilder>? _configureBuilder = configureBuilder;
 
     protected override ValueTask<IPublicClientApplication> CreateClientAsync(bool async, CancellationToken cancellationToken)
     {
@@ -24,11 +28,16 @@ internal class MsalPublicClient(
             .Create(ClientId)
             .WithB2CAuthority(AuthorityUri);
 
-        
+
         if (!string.IsNullOrEmpty(RedirectUrl))
         {
             pubAppBuilder = pubAppBuilder.WithRedirectUri(RedirectUrl);
         }
+
+        // Allow the consuming application to apply additional configuration to the builder,
+        // e.g. to enable the embedded WebView2 sign-in dialog via the
+        // Microsoft.Identity.Client.Desktop package.
+        _configureBuilder?.Invoke(pubAppBuilder);
 
         return new ValueTask<IPublicClientApplication>(pubAppBuilder.Build());
     }
@@ -92,6 +101,10 @@ internal class MsalPublicClient(
             if (browserOptions.SystemBrowserOptions != null)
             {
                 builder.WithSystemWebViewOptions(browserOptions.SystemBrowserOptions);
+            }
+            if (browserOptions.ParentActivityOrWindow != null)
+            {
+                builder.WithParentActivityOrWindow(browserOptions.ParentActivityOrWindow);
             }
         }
         return await builder


### PR DESCRIPTION
Windows desktop apps that want the embedded WebView2 sign-in dialog need the `Microsoft.Identity.Client.Desktop` package, which this `netstandard2.1` library cannot reference. This change exposes the underlying MSAL builder so a consuming app can enable the embedded dialog itself:

- `B2CInteractiveBrowserCredentialOptions.ConfigurePublicClientApplication` — an `Action<PublicClientApplicationBuilder>` invoked just before the client is built, so the consumer can call `WithWindowsEmbeddedBrowserSupport()`.
- `BrowserCustomizationOptions.ParentActivityOrWindow` — a `Func<IntPtr>` applied via `WithParentActivityOrWindow(...)` so the dialog is shown modally over the application window.

Combined with the existing `UseEmbeddedWebView`, these drive the embedded flow. Non-Windows callers leave the new options unset and keep using the system browser. Added `docs/wpf-embedded-signin.md` with the consumer setup and a code sample.