### PR TITLE
Fix embedded sign-in dialog owner window not being set

### DIFF
--- a/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
+++ b/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
@@ -102,7 +102,14 @@ internal class MsalPublicClient(
             }
             if (browserOptions.ParentActivityOrWindow != null)
             {
-                builder.WithParentActivityOrWindow(browserOptions.ParentActivityOrWindow);
+                // Resolve the handle and pass the IntPtr value: MSAL only sets the owner window for
+                // an IntPtr, not for a Func<IntPtr>. Skip a zero handle so MSAL falls back to an
+                // unowned dialog instead of throwing invalid_owner_window_type.
+                var parentWindow = browserOptions.ParentActivityOrWindow();
+                if (parentWindow != IntPtr.Zero)
+                {
+                    builder.WithParentActivityOrWindow(parentWindow);
+                }
             }
         }
         return await builder

--- a/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
+++ b/src/Eryph.GenePool.Client.Authentication/MsalPublicClient.cs
@@ -103,9 +103,21 @@ internal class MsalPublicClient(
             if (browserOptions.ParentActivityOrWindow != null)
             {
                 // Resolve the handle and pass the IntPtr value: MSAL only sets the owner window for
-                // an IntPtr, not for a Func<IntPtr>. Skip a zero handle so MSAL falls back to an
-                // unowned dialog instead of throwing invalid_owner_window_type.
-                var parentWindow = browserOptions.ParentActivityOrWindow();
+                // an IntPtr, not for a Func<IntPtr>. The callback may run on a non-UI thread here
+                // (AcquireTokenInteractiveAsync offloads to Task.Run when called from an STA thread),
+                // so a handle resolved with UI-thread affinity can throw. The parent window is
+                // optional, so treat a failure or a zero handle as "no parent" and let MSAL show an
+                // unowned dialog rather than failing the sign-in.
+                var parentWindow = IntPtr.Zero;
+                try
+                {
+                    parentWindow = browserOptions.ParentActivityOrWindow();
+                }
+                catch (Exception) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // Ignore: fall back to an unowned dialog.
+                }
+
                 if (parentWindow != IntPtr.Zero)
                 {
                     builder.WithParentActivityOrWindow(parentWindow);


### PR DESCRIPTION
`BrowserCustomizationOptions.ParentActivityOrWindow` is a `Func<IntPtr>`, but it was passed straight to MSAL's `WithParentActivityOrWindow`, which has no `Func<IntPtr>` overload. The call bound to `WithParentActivityOrWindow(object)`, and MSAL's internal `parent is IntPtr` check is false for a delegate, so the owner window was never set — the embedded WebView2 sign-in dialog floated unowned, non-modal and centered on screen instead of over the parent window.

Invoke the callback and pass the resulting `IntPtr` (which MSAL accepts as a boxed value), skipping a zero handle so MSAL falls back to an unowned dialog instead of throwing `invalid_owner_window_type`.